### PR TITLE
Add metrics to services with Prometheus implementation

### DIFF
--- a/cmd/alertgram/config.go
+++ b/cmd/alertgram/config.go
@@ -17,13 +17,17 @@ const (
 	descAMWebhookPath     = "The path where the server will be handling the alertmanager webhook alert requests."
 	descTelegramAPIToken  = "The token that will be used to use the telegram API to send the alerts."
 	descTelegramDefChatID = "The default ID of the chat (group/channel) in telegram where the alerts will be sent."
+	descMetricsListenAddr = "The listen address where the metrics will be being served."
+	descMetricsPath       = "The path where the metrics will be being served."
 	descDebug             = "Run the application in debug mode."
 	descNotifyDryRun      = "Dry run the notification and show in the terminal instead of sending."
 )
 
 const (
-	defAMListenAddr  = ":8080"
-	defAMWebhookPath = "/alerts"
+	defAMListenAddr      = ":8080"
+	defAMWebhookPath     = "/alerts"
+	defMetricsListenAddr = ":8081"
+	defMetricsPath       = "/metrics"
 )
 
 // Config has the configuration of the application.
@@ -32,6 +36,8 @@ type Config struct {
 	AlertmanagerWebhookPath string
 	TeletramAPIToken        string
 	TelegramChatID          int64
+	MetricsListenAddr       string
+	MetricsPath             string
 	DebugMode               bool
 	NotifyDryRun            bool
 
@@ -62,6 +68,8 @@ func (c *Config) registerFlags() {
 	c.app.Flag("alertmanager.webhook-path", descAMWebhookPath).Default(defAMWebhookPath).StringVar(&c.AlertmanagerWebhookPath)
 	c.app.Flag("telegram.api-token", descTelegramAPIToken).Required().StringVar(&c.TeletramAPIToken)
 	c.app.Flag("telegram.chat-id", descTelegramDefChatID).Required().Int64Var(&c.TelegramChatID)
+	c.app.Flag("metrics.listen-address", descMetricsListenAddr).Default(defMetricsListenAddr).StringVar(&c.MetricsListenAddr)
+	c.app.Flag("metrics.path", descMetricsPath).Default(defMetricsPath).StringVar(&c.MetricsPath)
 	c.app.Flag("notify.dry-run", descNotifyDryRun).BoolVar(&c.NotifyDryRun)
 	c.app.Flag("debug", descDebug).BoolVar(&c.DebugMode)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible
 	github.com/oklog/run v1.0.0
 	github.com/prometheus/alertmanager v0.19.0
+	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/common v0.7.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0

--- a/internal/forward/metrics.go
+++ b/internal/forward/metrics.go
@@ -1,0 +1,67 @@
+package forward
+
+import (
+	"context"
+	"time"
+
+	"github.com/slok/alertgram/internal/model"
+)
+
+// ServiceMetricsRecorder knows how to record metrics on forward.Service.
+type ServiceMetricsRecorder interface {
+	ObserveForwardServiceOpDuration(ctx context.Context, op string, success bool, t time.Duration)
+}
+
+type measureService struct {
+	rec  ServiceMetricsRecorder
+	next Service
+}
+
+// NewMeasureService wraps a service and measures using metrics.
+func NewMeasureService(rec ServiceMetricsRecorder, next Service) Service {
+	return &measureService{
+		rec:  rec,
+		next: next,
+	}
+}
+
+func (m measureService) Forward(ctx context.Context, ag *model.AlertGroup) (err error) {
+	defer func(t0 time.Time) {
+		m.rec.ObserveForwardServiceOpDuration(ctx, "Forward", err == nil, time.Since(t0))
+	}(time.Now())
+	return m.next.Forward(ctx, ag)
+}
+
+// NotifierMetricsRecorder knows how to record metrics on forward.Notifier.
+type NotifierMetricsRecorder interface {
+	ObserveForwardNotifierOpDuration(ctx context.Context, notifierType string, op string, success bool, t time.Duration)
+}
+
+type measureNotifier struct {
+	notifierType string
+	rec          NotifierMetricsRecorder
+	next         Notifier
+}
+
+// NewMeasureNotifier wraps a notifier and measures using metrics.
+func NewMeasureNotifier(rec NotifierMetricsRecorder, next Notifier) Notifier {
+	return &measureNotifier{
+		notifierType: next.Type(),
+		rec:          rec,
+		next:         next,
+	}
+}
+
+func (m measureNotifier) Notify(ctx context.Context, ag *model.AlertGroup) (err error) {
+	defer func(t0 time.Time) {
+		m.rec.ObserveForwardNotifierOpDuration(ctx, m.notifierType, "Notify", err == nil, time.Since(t0))
+	}(time.Now())
+	return m.next.Notify(ctx, ag)
+}
+
+func (m measureNotifier) Type() string {
+	defer func(t0 time.Time) {
+		m.rec.ObserveForwardNotifierOpDuration(context.TODO(), m.notifierType, "Type", true, time.Since(t0))
+	}(time.Now())
+	return m.next.Type()
+}

--- a/internal/metrics/prometheus/prometheus.go
+++ b/internal/metrics/prometheus/prometheus.go
@@ -1,0 +1,80 @@
+package prometheus
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/slok/alertgram/internal/forward"
+	"github.com/slok/alertgram/internal/notify"
+)
+
+const prefix = "alertgram"
+
+// Recorder knows how to measure the different metrics
+// interfaces of the application.
+type Recorder struct {
+	forwardServiceOpDurHistogram   *prometheus.HistogramVec
+	forwardNotifierOpDurHistogram  *prometheus.HistogramVec
+	templateRendererOpDurHistogram *prometheus.HistogramVec
+}
+
+// New returns a new Prometheus recorder for the app.
+func New(reg prometheus.Registerer) *Recorder {
+	r := &Recorder{
+		forwardServiceOpDurHistogram: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: prefix,
+			Subsystem: "forward",
+			Name:      "operation_duration_seconds",
+			Help:      "The duration of the operation in forward service.",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"operation", "success"}),
+
+		forwardNotifierOpDurHistogram: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: prefix,
+			Subsystem: "notifier",
+			Name:      "operation_duration_seconds",
+			Help:      "The duration of the operation in notifier.",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"type", "operation", "success"}),
+
+		templateRendererOpDurHistogram: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: prefix,
+			Subsystem: "template_renderer",
+			Name:      "operation_duration_seconds",
+			Help:      "The duration of the operation in template renderer.",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"type", "operation", "success"}),
+	}
+
+	// Register all the metrics.
+	reg.MustRegister(
+		r.forwardServiceOpDurHistogram,
+		r.forwardNotifierOpDurHistogram,
+		r.templateRendererOpDurHistogram,
+	)
+
+	return r
+}
+
+// ObserveForwardNotifierOpDuration satifies forward.NotifierMetricsRecorder interface.
+func (r Recorder) ObserveForwardNotifierOpDuration(ctx context.Context, notType string, op string, success bool, t time.Duration) {
+	r.forwardNotifierOpDurHistogram.WithLabelValues(notType, op, strconv.FormatBool(success)).Observe(t.Seconds())
+}
+
+// ObserveForwardServiceOpDuration satisfies forward.ServiceMetricsRecorder interface.
+func (r Recorder) ObserveForwardServiceOpDuration(ctx context.Context, op string, success bool, t time.Duration) {
+	r.forwardServiceOpDurHistogram.WithLabelValues(op, strconv.FormatBool(success)).Observe(t.Seconds())
+}
+
+// ObserveTemplateRendererOpDuration satisfies notify.TemplateRendererMetricsRecorder interface.
+func (r Recorder) ObserveTemplateRendererOpDuration(ctx context.Context, rendererType string, op string, success bool, t time.Duration) {
+	r.templateRendererOpDurHistogram.WithLabelValues(rendererType, op, strconv.FormatBool(success)).Observe(t.Seconds())
+}
+
+// Ensure that the recorder implements the different interfaces of the app.
+var _ forward.NotifierMetricsRecorder = &Recorder{}
+var _ forward.ServiceMetricsRecorder = &Recorder{}
+var _ notify.TemplateRendererMetricsRecorder = &Recorder{}

--- a/internal/notify/metrics.go
+++ b/internal/notify/metrics.go
@@ -1,0 +1,35 @@
+package notify
+
+import (
+	"context"
+	"time"
+
+	"github.com/slok/alertgram/internal/model"
+)
+
+// TemplateRendererMetricsRecorder knows how to record the metrics in the TemplateRenderer.
+type TemplateRendererMetricsRecorder interface {
+	ObserveTemplateRendererOpDuration(ctx context.Context, rendererType string, op string, success bool, t time.Duration)
+}
+
+type measureTemplateRenderer struct {
+	rendererType string
+	rec          TemplateRendererMetricsRecorder
+	next         TemplateRenderer
+}
+
+// NewMeasureTemplateRenderer wraps a template renderer and measures using metrics.
+func NewMeasureTemplateRenderer(rendererType string, rec TemplateRendererMetricsRecorder, next TemplateRenderer) TemplateRenderer {
+	return &measureTemplateRenderer{
+		rendererType: rendererType,
+		rec:          rec,
+		next:         next,
+	}
+}
+
+func (m measureTemplateRenderer) Render(ctx context.Context, ag *model.AlertGroup) (_ string, err error) {
+	defer func(t0 time.Time) {
+		m.rec.ObserveTemplateRendererOpDuration(ctx, m.rendererType, "Render", err == nil, time.Since(t0))
+	}(time.Now())
+	return m.next.Render(ctx, ag)
+}


### PR DESCRIPTION
This PR adds Prometheus metrics to the different services, the metrics implementation has been decoupled from the services itself by using `MetricsRecorder` interfaces and the implementation is grouped in one app metrics recorder, in this case for Prometheus.

