### PR TITLE
Set notification chat id based on alert label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [unreleased] - YYYY-MM-DD
 
+### Added
+
+- Forward alerts by custom chat ID based on alert labels.
+
 ## [0.2.1] - 2019-12-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -105,9 +105,11 @@ There are 3 levels where you could customize the notification chat:
 - By default: Using the required `--telegram.chat-id` flag.
 - At URL level: using [query string] parameter, e.g. `0.0.0.0:8080/alerts?chat-id=-1009876543210`.
   This query param can be customized with `--alertmanager.chat-id-query-string` flag.
-- At alert level: TODO
+- At alert level: If alerts have a label with the chat ID the alert notification will be forwarded to
+  that label content. Use the flag `--alert.label-chat-id` to customize the label name, by default
+  is `chat_id`.
 
-The preference is in order from the lowest to the highest: Default, URL, Alert.
+The preference is in order from highest to lowest: Alert, URL, Default.
 
 ### Can I use custom templates?
 

--- a/cmd/alertgram/config.go
+++ b/cmd/alertgram/config.go
@@ -29,6 +29,7 @@ const (
 	descDebug              = "Run the application in debug mode."
 	descNotifyDryRun       = "Dry run the notification and show in the terminal instead of sending."
 	descNotifyTemplatePath = "The path to set a custom template for the notification messages."
+	descAlertLabelChatID   = "The label of the alert that will carry the chat id to forward the alert."
 )
 
 const (
@@ -40,6 +41,7 @@ const (
 	defMetricsPath       = "/metrics"
 	defMetricsHCPath     = "/status"
 	defDMSInterval       = "15m"
+	defAlertLabelChatID  = "chat_id"
 )
 
 // Config has the configuration of the application.
@@ -59,6 +61,7 @@ type Config struct {
 	NotifyTemplate                 *os.File
 	DebugMode                      bool
 	NotifyDryRun                   bool
+	AlertLabelChatID               string
 
 	app *kingpin.Application
 }
@@ -97,6 +100,7 @@ func (c *Config) registerFlags() {
 	c.app.Flag("dead-mans-switch.chat-id", descDMSChatID).StringVar(&c.DMSChatID)
 	c.app.Flag("notify.dry-run", descNotifyDryRun).BoolVar(&c.NotifyDryRun)
 	c.app.Flag("notify.template-path", descNotifyTemplatePath).FileVar(&c.NotifyTemplate)
+	c.app.Flag("alert.label-chat-id", descAlertLabelChatID).Default(defAlertLabelChatID).StringVar(&c.AlertLabelChatID)
 	c.app.Flag("debug", descDebug).BoolVar(&c.DebugMode)
 }
 

--- a/cmd/alertgram/main.go
+++ b/cmd/alertgram/main.go
@@ -90,7 +90,14 @@ func (m *Main) Run() error {
 	{
 
 		// Alert forward.
-		forwardSvc := forward.NewService([]forward.Notifier{notifier}, m.logger)
+		forwardSvc, err := forward.NewService(forward.ServiceConfig{
+			AlertLabelChatID: m.cfg.AlertLabelChatID,
+			Notifiers:        []forward.Notifier{notifier},
+			Logger:           m.logger,
+		})
+		if err != nil {
+			return err
+		}
 		forwardSvc = forward.NewMeasureService(metricsRecorder, forwardSvc)
 
 		// Dead man's switch.

--- a/internal/forward/forward.go
+++ b/internal/forward/forward.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/slok/alertgram/internal/internalerrors"
 	"github.com/slok/alertgram/internal/log"
 	"github.com/slok/alertgram/internal/model"
 )
@@ -24,17 +25,44 @@ type Service interface {
 	Forward(ctx context.Context, props Properties, alertGroup *model.AlertGroup) error
 }
 
+// ServiceConfig is the service configuration.
+type ServiceConfig struct {
+	AlertLabelChatID string
+	Notifiers        []Notifier
+	Logger           log.Logger
+}
+
+func (c *ServiceConfig) defaults() error {
+	if len(c.Notifiers) == 0 {
+		return errors.New("notifiers can't be empty")
+	}
+
+	if c.Logger == nil {
+		c.Logger = log.Dummy
+	}
+
+	return nil
+}
+
 type service struct {
+	cfg       ServiceConfig
 	notifiers []Notifier
 	logger    log.Logger
 }
 
 // NewService returns a new forward.Service.
-func NewService(notifiers []Notifier, l log.Logger) Service {
-	return &service{
-		notifiers: notifiers,
-		logger:    l.WithValues(log.KV{"service": "forward.Service"}),
+func NewService(cfg ServiceConfig) (Service, error) {
+	err := cfg.defaults()
+	if err != nil {
+		err := fmt.Errorf("%w: %s", internalerrors.ErrInvalidConfiguration, err)
+		return nil, fmt.Errorf("could not create forward service instance because invalid configuration: %w", err)
 	}
+
+	return &service{
+		cfg:       cfg,
+		notifiers: cfg.Notifiers,
+		logger:    cfg.Logger.WithValues(log.KV{"service": "forward.Service"}),
+	}, nil
 }
 
 var (
@@ -48,18 +76,62 @@ func (s service) Forward(ctx context.Context, props Properties, alertGroup *mode
 		return fmt.Errorf("alertgroup can't be empty: %w", ErrInvalidAlertGroup)
 	}
 
-	// TODO(slok): Add concurrency using workers.
-	notification := Notification{
-		AlertGroup: *alertGroup,
-		ChatID:     props.CustomChatID,
+	notifications, err := s.createNotifications(props, alertGroup)
+	if err != nil {
+		return fmt.Errorf("could not prepare notifications from the alerts: %w", err)
 	}
-	for _, not := range s.notifiers {
-		err := not.Notify(ctx, notification)
-		if err != nil {
-			s.logger.WithValues(log.KV{"notifier": not.Type(), "alertGroupID": alertGroup.ID}).
-				Errorf("could not notify alert group: %s", err)
+
+	// TODO(slok): Add concurrency using workers.
+	for _, notifier := range s.notifiers {
+		for _, notification := range notifications {
+			err := notifier.Notify(ctx, *notification)
+			if err != nil {
+				s.logger.WithValues(log.KV{"notifier": notifier.Type(), "alertGroupID": alertGroup.ID, "chatID": notification.ChatID}).
+					Errorf("could not notify alert group: %s", err)
+			}
 		}
 	}
 
 	return nil
+}
+
+func (s service) createNotifications(props Properties, alertGroup *model.AlertGroup) (ns []*Notification, err error) {
+	// Decompose the alerts in groups by chat IDs based on the
+	// alert chat ID labels. If the alerts don't have the chat ID
+	// label they will remain on the default group.
+	agByChatID := map[string]*model.AlertGroup{}
+	for _, a := range alertGroup.Alerts {
+		chatID := a.Labels[s.cfg.AlertLabelChatID]
+		ag, ok := agByChatID[chatID]
+		if !ok {
+			id := alertGroup.ID
+			if chatID != "" {
+				id = fmt.Sprintf("%s-%s", alertGroup.ID, chatID)
+			}
+			ag = &model.AlertGroup{
+				ID:     id,
+				Labels: alertGroup.Labels,
+			}
+			agByChatID[chatID] = ag
+		}
+
+		ag.Alerts = append(ag.Alerts, a)
+	}
+
+	// Create notifications based on the alertgroups.
+	notifications := []*Notification{}
+	for chatID, ag := range agByChatID {
+		// If no custom alert based chat then fallback to
+		// properties custom chat (normally received by upper
+		// layers by URL).
+		if chatID == "" {
+			chatID = props.CustomChatID
+		}
+		notifications = append(notifications, &Notification{
+			AlertGroup: *ag,
+			ChatID:     chatID,
+		})
+	}
+
+	return notifications, nil
 }

--- a/internal/forward/forward_test.go
+++ b/internal/forward/forward_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/slok/alertgram/internal/forward"
-	"github.com/slok/alertgram/internal/log"
 	forwardmock "github.com/slok/alertgram/internal/mocks/forward"
 	"github.com/slok/alertgram/internal/model"
 )
@@ -18,6 +18,7 @@ var errTest = errors.New("whatever")
 
 func TestServiceForward(t *testing.T) {
 	tests := map[string]struct {
+		cfg        forward.ServiceConfig
 		props      forward.Properties
 		alertGroup *model.AlertGroup
 		mock       func(ns []*forwardmock.Notifier)
@@ -73,18 +74,90 @@ func TestServiceForward(t *testing.T) {
 				}
 			},
 		},
+
+		"Alerts that have the label for custom chat ids should be grouped together.": {
+			cfg: forward.ServiceConfig{
+				AlertLabelChatID: "test_chat_id",
+			},
+			props: forward.Properties{
+				CustomChatID: "-1001234567890",
+			},
+			alertGroup: &model.AlertGroup{
+				ID: "test-group",
+				Alerts: []model.Alert{
+					{Name: "test-1", Labels: map[string]string{"test_chat_id": ""}},
+					{Name: "test-2", Labels: map[string]string{"test_chat_id": "chat2"}},
+					{Name: "test-3", Labels: map[string]string{"test_chat_id": "chat1"}},
+					{Name: "test-4", Labels: map[string]string{"test_chat_id": "chat2"}},
+					{Name: "test-3", Labels: map[string]string{"test_chat_id": "chat1"}},
+					{Name: "test-6", Labels: map[string]string{"test_chat_id": "chat3"}},
+					{Name: "test-7", Labels: map[string]string{"test_chat_id": ""}},
+					{Name: "test-8", Labels: map[string]string{"test_chat_id": ""}},
+					{Name: "test-9", Labels: map[string]string{"test_chat_id": "chat1"}},
+				},
+			},
+			mock: func(ns []*forwardmock.Notifier) {
+				expNotChatDef := forward.Notification{
+					ChatID: "-1001234567890",
+					AlertGroup: model.AlertGroup{ID: "test-group",
+						Alerts: []model.Alert{
+							{Name: "test-1", Labels: map[string]string{"test_chat_id": ""}},
+							{Name: "test-7", Labels: map[string]string{"test_chat_id": ""}},
+							{Name: "test-8", Labels: map[string]string{"test_chat_id": ""}},
+						},
+					},
+				}
+				expNotChat1 := forward.Notification{
+					ChatID: "chat1",
+					AlertGroup: model.AlertGroup{ID: "test-group-chat1",
+						Alerts: []model.Alert{
+							{Name: "test-3", Labels: map[string]string{"test_chat_id": "chat1"}},
+							{Name: "test-3", Labels: map[string]string{"test_chat_id": "chat1"}},
+							{Name: "test-9", Labels: map[string]string{"test_chat_id": "chat1"}},
+						},
+					},
+				}
+				expNotChat2 := forward.Notification{
+					ChatID: "chat2",
+					AlertGroup: model.AlertGroup{ID: "test-group-chat2",
+						Alerts: []model.Alert{
+							{Name: "test-2", Labels: map[string]string{"test_chat_id": "chat2"}},
+							{Name: "test-4", Labels: map[string]string{"test_chat_id": "chat2"}},
+						},
+					},
+				}
+				expNotChat3 := forward.Notification{
+					ChatID: "chat3",
+					AlertGroup: model.AlertGroup{ID: "test-group-chat3",
+						Alerts: []model.Alert{
+							{Name: "test-6", Labels: map[string]string{"test_chat_id": "chat3"}},
+						},
+					},
+				}
+				for _, n := range ns {
+					n.On("Notify", mock.Anything, expNotChatDef).Once().Return(nil)
+					n.On("Notify", mock.Anything, expNotChat1).Once().Return(nil)
+					n.On("Notify", mock.Anything, expNotChat2).Once().Return(nil)
+					n.On("Notify", mock.Anything, expNotChat3).Once().Return(nil)
+				}
+			},
+		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
+			require := require.New(t)
 
 			mn1 := &forwardmock.Notifier{}
 			mn2 := &forwardmock.Notifier{}
 			test.mock([]*forwardmock.Notifier{mn1, mn2})
 
-			svc := forward.NewService([]forward.Notifier{mn1, mn2}, log.Dummy)
-			err := svc.Forward(context.TODO(), test.props, test.alertGroup)
+			test.cfg.Notifiers = []forward.Notifier{mn1, mn2}
+			svc, err := forward.NewService(test.cfg)
+			require.NoError(err)
+
+			err = svc.Forward(context.TODO(), test.props, test.alertGroup)
 
 			if test.expErr != nil && assert.Error(err) {
 				assert.True(errors.Is(err, test.expErr))


### PR DESCRIPTION
This PR adds a new way of selecting the forwarding chat id, it's based on the alert label, if an alert has a specific label id, the forwarding service will group by that chat id label.