### PR TITLE
Support resolved alerts on default templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [unreleased] - YYYY-MM-DD
 
+### Added
+
+- Default template supports resolved alerts
+- Helpers on alert group model to group alerts by status.
+
 ## [0.3.1] - 2019-06-02
 
 ### Changed

--- a/internal/http/alertmanager/alertmanager_test.go
+++ b/internal/http/alertmanager/alertmanager_test.go
@@ -45,11 +45,14 @@ func getBaseAlerts() *model.AlertGroup {
 	al1.ID += "-1"
 	al2 := getBaseAlert()
 	al2.ID += "-2"
+	al3 := getBaseAlert()
+	al3.ID += "-3"
+	al3.Status = model.AlertStatusResolved
 
 	return &model.AlertGroup{
 		ID:     "test-group",
 		Labels: map[string]string{"glK1": "glV1", "glK2": "glV2"},
-		Alerts: []model.Alert{al1, al2},
+		Alerts: []model.Alert{al1, al2, al3},
 	}
 }
 
@@ -70,12 +73,15 @@ func getBaseAlertmanagerAlerts() webhook.Message {
 	al1.Fingerprint += "-1"
 	al2 := getBaseAlertmanagerAlert()
 	al2.Fingerprint += "-2"
+	al3 := getBaseAlertmanagerAlert()
+	al3.Fingerprint += "-3"
+	al3.Status = string(prommodel.AlertResolved)
 
 	return webhook.Message{
 		Data: &template.Data{
 			Receiver:          "test-recv",
 			Status:            string(prommodel.AlertFiring),
-			Alerts:            template.Alerts{al1, al2},
+			Alerts:            template.Alerts{al1, al2, al3},
 			GroupLabels:       map[string]string{"glK1": "glV1", "glK2": "glV2"},
 			CommonLabels:      map[string]string{"gclK1": "gclV1", "gclK2": "gclV2"},
 			CommonAnnotations: map[string]string{"gcaK1": "gcaV1", "gcaK2": "gcaV2"},

--- a/internal/http/alertmanager/mapper.go
+++ b/internal/http/alertmanager/mapper.go
@@ -27,10 +27,9 @@ func (a alertGroupV4) toDomain() (*model.AlertGroup, error) {
 	}
 
 	// Map alerts.
-	alerts := make([]model.Alert, len(a.Alerts))
-	for i := 0; i < len(a.Alerts); i++ {
-		alert := a.Alerts[i]
-		alerts[i] = model.Alert{
+	alerts := make([]model.Alert, 0, len(a.Alerts))
+	for _, alert := range a.Alerts {
+		modelAlert := model.Alert{
 			ID:           alert.Fingerprint,
 			Name:         alert.Labels[prommodel.AlertNameLabel],
 			StartsAt:     alert.StartsAt,
@@ -40,6 +39,7 @@ func (a alertGroupV4) toDomain() (*model.AlertGroup, error) {
 			Annotations:  alert.Annotations,
 			GeneratorURL: alert.GeneratorURL,
 		}
+		alerts = append(alerts, modelAlert)
 	}
 
 	ag := &model.AlertGroup{

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -51,6 +51,39 @@ type AlertGroup struct {
 	ID string
 	// Labels are the labels of the group.
 	Labels map[string]string
-	// Alerts are the alerts in the group.
+	// Alerts are all the alerts in the group (firing, resolved, unknown...).
 	Alerts []Alert
+}
+
+// FiringAlerts returns the firing alerts.
+func (a AlertGroup) FiringAlerts() []Alert { return a.groupByStatusAlerts(AlertStatusFiring) }
+
+// ResolvedAlerts returns the resolved alerts.
+func (a AlertGroup) ResolvedAlerts() []Alert { return a.groupByStatusAlerts(AlertStatusResolved) }
+
+// HasFiring returns true if it has firing alerts.
+func (a AlertGroup) HasFiring() bool { return a.hasAlertByStatus(AlertStatusFiring) }
+
+// HasResolved returns true if it has resolved alerts.
+func (a AlertGroup) HasResolved() bool { return a.hasAlertByStatus(AlertStatusResolved) }
+
+func (a AlertGroup) hasAlertByStatus(status AlertStatus) bool {
+	for _, al := range a.Alerts {
+		if al.Status == status {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (a AlertGroup) groupByStatusAlerts(status AlertStatus) []Alert {
+	var alerts []Alert
+	for _, al := range a.Alerts {
+		if al.Status == status {
+			alerts = append(alerts, al)
+		}
+	}
+
+	return alerts
 }

--- a/internal/notify/template.go
+++ b/internal/notify/template.go
@@ -65,11 +65,38 @@ func (defRenderer) Render(_ context.Context, ag *model.AlertGroup) (string, erro
 }
 
 var defTemplate = template.Must(template.New("def").Funcs(sprig.FuncMap()).Parse(`
+{{- if .HasFiring }}
 🚨🚨 FIRING ALERTS 🚨🚨
-{{- range .Alerts }}
-{{- if .IsFiring }}
+{{- range .FiringAlerts }}
 
 💥💥💥 <b>{{ .Labels.alertname }}</b> 💥💥💥
+  {{ .Annotations.message }}
+  {{- range $key, $value := .Labels }}
+	{{- if ne $key "alertname" }}  
+	{{- if hasPrefix "http" $value }}
+	🔹 <a href="{{ $value }}">{{ $key }}</a>
+	{{- else }}
+	🔹 {{ $key }}: {{ $value }}
+	{{- end}}
+	{{-  end }}
+  {{- end}}
+  {{- range $key, $value := .Annotations }}
+	{{- if ne $key "message" }}
+	{{- if hasPrefix "http" $value }}
+	🔸 <a href="{{ $value }}">{{ $key }}</a>
+	{{- else }}
+	🔸 {{ $key }}: {{ $value }}
+	{{- end}}
+	{{- end}}
+  {{- end}}
+{{- end }}
+{{- end }}
+{{- if .HasResolved }}
+
+✅✅ RESOLVED ALERTS ✅✅
+{{- range .ResolvedAlerts }}
+
+🟢🟢🟢 <b>{{ .Labels.alertname }}</b> 🟢🟢🟢
   {{ .Annotations.message }}
   {{- range $key, $value := .Labels }}
 	{{- if ne $key "alertname" }}  

--- a/testdata/alerts/base.json
+++ b/testdata/alerts/base.json
@@ -59,6 +59,25 @@
       },
       "startsAt": "2019-12-06T20:46:37.903Z",
       "generatorURL": "https://example.com/graph"
+    },
+    {
+      "status": "resolved",
+      "labels": {
+        "alertname": "ServicePodIsPending",
+        "instance": "10.0.0.221:20464",
+        "job": "kubernetes-metrics2",
+        "owner": "team1",
+        "severity": "telegram",
+        "env": "production",
+        "pod": "ns3/pod-service3-954bb8c86-p6svs"
+      },
+      "annotations": {
+        "message": "The has been pending more than 10 minutes",
+        "Graph": "https://prometheus.test/d/taQlRuxik/k8s-cluster-summary?orgId=1&refresh=30s&fullscreen&panelId=11&from=now-3h&to=now&var-cluster=prometheus&var-ds=&var-datasource=prometheus&var-node=k8s-master&var-namespace=monitoring",
+        "Runbook": "https://github.test/runbooks/pod-restarting.md"
+      },
+      "startsAt": "2019-12-06T20:46:37.903Z",
+      "generatorURL": "https://example.com/graph"
     }
   ],
   "groupLabels": {


### PR DESCRIPTION
Fixes #31

This MR adds new helpers on the alert group model so we can get the alerts by status on the templates.

Also it adds suppport for resolved alerts on default template:

![](https://i.imgur.com/ayHIZxk.jpg)