### PR TITLE
Fix DMS path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ this alert (e.g. network problems), Alertmanager will send an alert to Telegram 
 You could use the same alertgram or another instance, usually in other machine, cluster... so if the cluster/machine fails, your
 is isolated and could notify you.
 
-To Enable Alertgram's DMS use `--dead-mans-switch.enable` to enable. By default it will be listening in `/alert/dms`, with a
+To Enable Alertgram's DMS use `--dead-mans-switch.enable` to enable. By default it will be listening in `/alerts/dms`, with a
 `15m` interval and use the telegrams default notifier and chat ID. To customize this settings use:
 
 - `--dead-mans-switch.interval`: To configure the interval.


### PR DESCRIPTION
According to https://github.com/slok/alertgram/blob/816a24abae4cd7844193f4998413ad718d2e6ab2/cmd/alertgram/config.go#L39 the dead man's switch path is `/alerts/dms'. There seems to be a typo in the README.